### PR TITLE
Add Money().toString() option to exclude currency

### DIFF
--- a/src/money/index.ts
+++ b/src/money/index.ts
@@ -133,6 +133,8 @@ export interface MoneyToStringOptions {
   preferFractionalSymbol?: boolean
   /** Rounding mode for number formatting */
   roundingMode?: RoundingMode
+  /** Exclude currency symbol/code from the formatted string */
+  excludeCurrency?: boolean
 }
 
 /**
@@ -345,6 +347,7 @@ export function formatWithIntlCurrency(
   maxDecimals?: number | bigint,
   minDecimals?: number | bigint,
   roundingMode?: RoundingMode,
+  excludeCurrency: boolean = false,
 ): string {
   // Money should have FixedPointNumber amount here due to formatting conversion
   const fp = money.amount as FixedPointNumber
@@ -414,8 +417,8 @@ export function formatWithIntlCurrency(
   }
 
   const formatterOptions: NumberFormatOptionsWithRounding = {
-    style: "currency",
-    currency: currencyCode,
+    style: excludeCurrency ? "decimal" : "currency",
+    currency: excludeCurrency ? undefined : currencyCode,
     notation: compact ? "compact" : "standard",
     compactDisplay: compact ? "short" : undefined,
     minimumFractionDigits: finalMinDecimals,
@@ -458,6 +461,7 @@ export function formatWithCustomFormatting(
   preferSymbol: boolean = false,
   preferFractionalSymbol: boolean = false,
   roundingMode?: RoundingMode,
+  excludeCurrency: boolean = false,
 ): string {
   // Handle fractional unit conversion if specified
   const { decimalString, unitSuffix } = convertToPreferredUnit(
@@ -536,6 +540,11 @@ export function formatWithCustomFormatting(
 
   // Convert decimal string to number for formatting
   const formattedNumber = formatter.format(decimalString)
+
+  // Return just the formatted number if currency should be excluded
+  if (excludeCurrency) {
+    return formattedNumber
+  }
 
   // Handle fractional unit symbol formatting
   if (preferFractionalSymbol && preferredUnit && unitSuffix) {
@@ -1541,6 +1550,7 @@ export class Money {
       preferSymbol = false,
       preferFractionalSymbol = false,
       roundingMode,
+      excludeCurrency = false,
     } = options
 
     // Convert RationalNumber to FixedPointNumber for formatting
@@ -1559,6 +1569,7 @@ export class Money {
         maxDecimals,
         minDecimals,
         roundingMode,
+        excludeCurrency,
       )
     }
     return formatWithCustomFormatting(
@@ -1571,6 +1582,7 @@ export class Money {
       preferSymbol,
       preferFractionalSymbol,
       roundingMode,
+      excludeCurrency,
     )
   }
 

--- a/test/money.test.ts
+++ b/test/money.test.ts
@@ -2552,6 +2552,53 @@ describe("Money", () => {
         expect(money.toString({ minDecimals: 2, preferredUnit: "satoshi" })).toBe("100,000,000.00 satoshis")
       })
     })
+    describe("excludeCurrency option", () => {
+      it("should exclude currency symbol/code when excludeCurrency is true for ISO currencies", () => {
+        const money = new Money({
+          asset: usd,
+          amount: { amount: 100050n, decimals: 2n }, // $1000.50
+        })
+        expect(money.toString({ excludeCurrency: true })).toBe("1,000.50")
+        expect(money.toString({ excludeCurrency: false })).toBe("$1,000.50")
+        expect(money.toString()).toBe("$1,000.50") // default behavior
+      })
+      it("should exclude currency code when excludeCurrency is true for non-ISO currencies", () => {
+        const money = new Money({
+          asset: btc,
+          amount: { amount: 150000000n, decimals: 8n }, // 1.5 BTC
+        })
+        expect(money.toString({ excludeCurrency: true })).toBe("1.5")
+        expect(money.toString({ excludeCurrency: false })).toBe("1.5 BTC")
+        expect(money.toString()).toBe("1.5 BTC") // default behavior
+      })
+      it("should exclude symbol when using preferSymbol and excludeCurrency is true", () => {
+        const money = new Money({
+          asset: btc,
+          amount: { amount: 200000000n, decimals: 8n }, // 2.0 BTC
+        })
+        expect(money.toString({ preferSymbol: true, excludeCurrency: true })).toBe("2")
+        expect(money.toString({ preferSymbol: true, excludeCurrency: false })).toBe("₿2")
+        expect(money.toString({ preferSymbol: true })).toBe("₿2") // default behavior
+      })
+      it("should exclude fractional unit when using preferredUnit and excludeCurrency is true", () => {
+        const money = new Money({
+          asset: btc,
+          amount: { amount: 100000000n, decimals: 8n }, // 1.0 BTC
+        })
+        expect(money.toString({ preferredUnit: "sat", excludeCurrency: true })).toBe("100,000,000")
+        expect(money.toString({ preferredUnit: "sat", excludeCurrency: false })).toBe("100,000,000 sats")
+        expect(money.toString({ preferredUnit: "sat" })).toBe("100,000,000 sats") // default behavior
+      })
+      it("should work with other formatting options", () => {
+        const money = new Money({
+          asset: usd,
+          amount: { amount: 123456n, decimals: 2n }, // $1234.56
+        })
+        expect(money.toString({ excludeCurrency: true, locale: "de-DE" })).toBe("1.234,56")
+        expect(money.toString({ excludeCurrency: true, maxDecimals: 1 })).toBe("1,234.6")
+        expect(money.toString({ excludeCurrency: true, minDecimals: 3 })).toBe("1,234.560")
+      })
+    })
   })
 
   describe("formatting utility functions", () => {


### PR DESCRIPTION
This makes it easier to get a well-formatted version of the amount without dropping down to dealing with `FixedPoint`s directly.