### PR TITLE
Add mats & MUSD

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -1436,8 +1436,8 @@ export const USDT: Currency = {
 }
 
 export const MATS: Currency = {
-  name: "MATS",
-  code: "MATS",
+  name: "Mezo magic sats",
+  code: "mats",
   decimals: 0n,
   symbol: "mats",
   iso4217Support: false,


### PR DESCRIPTION
### Notes
This adds both MATS and MUSD to our currency list so we can use it as part of the `Money()` functions elsewhere.